### PR TITLE
Normalize tool schemas before Gemini calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,24 @@ def flatten(xss):
     return [x for xs in xss for x in xs]
 
 
+def _snake_to_camel(name: str) -> str:
+    """Convert snake_case names to camelCase."""
+    parts = name.split("_")
+    return parts[0] + "".join(p.title() for p in parts[1:]) if len(parts) > 1 else name
+
+
+def normalize_schema(value):
+    """Recursively convert snake_case keys to camelCase in a JSON schema."""
+    if isinstance(value, dict):
+        return {
+            _snake_to_camel(k): normalize_schema(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [normalize_schema(v) for v in value]
+    return value
+
+
 @cl.on_mcp_connect
 async def on_mcp(connection, session: ClientSession):
     result = await session.list_tools()
@@ -86,7 +104,7 @@ async def call_gemini(chat_messages):
         genai.types.FunctionDeclaration(
             name=t["name"],
             description=t["description"],
-            parameters=t["input_schema"],
+            parameters=normalize_schema(t["input_schema"]),
         )
         for t in all_tools
     ]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,3 +119,41 @@ def test_call_gemini(app_module):
     assert captured['model'] == app.MODEL_NAME
     assert captured['contents'][0].role == 'user'
     assert captured['contents'][0].parts[0].text == 'hi'
+
+
+def test_call_gemini_schema_normalization(app_module):
+    app, cl = app_module
+    schema = {
+        'type': 'object',
+        'properties': {
+            'numbers': {
+                'type': 'array',
+                'max_items': 3,
+            }
+        },
+        'additional_properties': False,
+    }
+    cl.user_session.set('mcp_tools', {
+        'c1': [{
+            'name': 'foo',
+            'description': 'd',
+            'input_schema': schema,
+        }]
+    })
+    cl.user_session.set('regular_tools', [])
+
+    captured = {}
+
+    async def fake_generate_content(model, contents, config):
+        captured['declarations'] = config.tools[0].function_declarations
+        return types.SimpleNamespace(candidates=[
+            types.SimpleNamespace(content=types.SimpleNamespace(parts=[types.SimpleNamespace(text='ok')]))
+        ])
+
+    app.client.aio.models.generate_content = fake_generate_content
+
+    asyncio.run(app.call_gemini([]))
+    params = captured['declarations'][0].parameters
+    assert 'additionalProperties' in params
+    assert 'additional_properties' not in params
+    assert params['properties']['numbers']['maxItems'] == 3


### PR DESCRIPTION
## Summary
- add `normalize_schema` helper to convert snake_case to camelCase
- ensure FunctionDeclaration parameters use normalized schema
- cover schema normalization with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe5036720832ea8da0892d8a272ea