### PR TITLE
Implement Chainlit Gemini MCP example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+# Chainlit config
+.chainlit/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Instructions for Codex Agents
+
+This project is a Python 3.11+ package. Use `uv` to manage and install the
+`[dev]` dependencies:
+
+```bash
+uv pip install -e .[dev]
+```
+
+## Code Style and Linting
+
+Run `black --check .` before committing to ensure code is properly formatted.
+
+## Testing
+
+Run the unit test suite with:
+
+```bash
+pytest -q
+```
+
+All tests must pass before you submit a PR.
+
+## Pull Request Guidance
+
+Include a concise summary of the changes and reference relevant lines in your
+commit. Provide a **Testing** section with the test results. If a command cannot
+run in the Codex environment, note this with the sentence:
+"Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies."

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ chainlit run src/chainlit_gemini_mcp/app.py
 
 Make sure to set the `GOOGLE_API_KEY` environment variable so that the
 Gemini client can authenticate.
+
+## Logging
+
+The application uses Python's `logging` module. Set the `LOGLEVEL`
+environment variable to `DEBUG` to see verbose output when starting the
+app:
+
+```bash
+LOGLEVEL=DEBUG chainlit run src/chainlit_gemini_mcp/app.py
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # chainlit-gemini-mcp
+
+This project demonstrates how to use **Chainlit** with the Google
+**Gemini** SDK to call tools exposed through an MCP server.
+
+## Development
+
+Create a virtual environment and install the dependencies using
+[uv](https://github.com/astral-sh/uv):
+
+```bash
+uv pip install -e .[dev]
+```
+
+Run the tests with `pytest`:
+
+```bash
+pytest
+```
+
+Start the Chainlit application:
+
+```bash
+chainlit run src/chainlit_gemini_mcp/app.py
+```
+
+Make sure to set the `GOOGLE_API_KEY` environment variable so that the
+Gemini client can authenticate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "chainlit-gemini-mcp"
+version = "0.1.0"
+description = "Chainlit example integrating Gemini with MCP"
+requires-python = ">=3.11"
+dependencies = [
+    "chainlit>=2.5.5",
+    "google-genai>=1.19.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=24.0",
+]
+
+[build-system]
+requires = ["uv", "setuptools"]
+build-backend = "setuptools.build_meta"

--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -16,7 +16,7 @@ from chainlit_gemini_mcp.mcp_utils import (
 )
 
 
-MODEL_NAME = "gemini-2.0-pro"  # default model
+MODEL_NAME = "gemini-2.5-flash-preview-05-20"  # default model
 client = get_client()
 
 

--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -3,8 +3,12 @@ import chainlit as cl
 
 from google.genai import types
 
-from .gemini_client import get_client
-from .mcp_utils import call_mcp_tool, store_tools, remove_tools
+from chainlit_gemini_mcp.gemini_client import get_client
+from chainlit_gemini_mcp.mcp_utils import (
+    call_mcp_tool,
+    store_tools,
+    remove_tools,
+)
 
 
 MODEL_NAME = "gemini-2.0-pro"  # default model

--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
+import os
+import logging
 import chainlit as cl
+
+logging.basicConfig(level=os.getenv("LOGLEVEL", "INFO").upper())
+logger = logging.getLogger(__name__)
 
 from google.genai import types
 
@@ -17,6 +22,7 @@ client = get_client()
 
 async def get_current_weather(location: str) -> str:
     """Delegate a weather query to an MCP tool."""
+    logger.info("get_current_weather called with location=%s", location)
     mcp_tools = cl.user_session.get("mcp_tools", {})
     mcp_sessions = {
         name: session

--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import chainlit as cl
+
+from google.genai import types
+
+from .gemini_client import get_client
+from .mcp_utils import call_mcp_tool, store_tools, remove_tools
+
+
+MODEL_NAME = "gemini-2.0-pro"  # default model
+client = get_client()
+
+
+async def get_current_weather(location: str) -> str:
+    """Delegate a weather query to an MCP tool."""
+    mcp_tools = cl.user_session.get("mcp_tools", {})
+    mcp_sessions = {
+        name: session
+        for name, (session, _) in getattr(
+            cl.context.session, "mcp_sessions", {}
+        ).items()
+    }
+    result = await call_mcp_tool(
+        "get_current_weather",
+        {"location": location},
+        mcp_tools,
+        mcp_sessions,
+    )
+    return str(result)
+
+
+@cl.on_mcp_connect
+async def on_mcp_connect(connection, session):
+    await store_tools(connection, session)
+
+
+@cl.on_mcp_disconnect
+async def on_mcp_disconnect(name, session):
+    await remove_tools(name)
+
+
+@cl.on_message
+async def on_message(message: cl.Message):
+    response = await client.aio.models.generate_content(
+        model=MODEL_NAME,
+        contents=message.content,
+        config=types.GenerateContentConfig(tools=[get_current_weather]),
+    )
+    await cl.Message(content=response.text).send()

--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -56,4 +56,5 @@ async def on_message(message: cl.Message):
         contents=message.content,
         config=types.GenerateContentConfig(tools=[get_current_weather]),
     )
+    logger.debug("Model response text: %s", response.text)
     await cl.Message(content=response.text).send()

--- a/src/chainlit_gemini_mcp/gemini_client.py
+++ b/src/chainlit_gemini_mcp/gemini_client.py
@@ -1,0 +1,12 @@
+import os
+import google.genai as genai
+
+
+def get_client(api_key: str | None = None) -> genai.Client:
+    """Create a Google Gemini client using the provided API key or
+    the ``GOOGLE_API_KEY`` environment variable.
+    """
+    key = api_key or os.getenv("GOOGLE_API_KEY")
+    if not key:
+        raise ValueError("GOOGLE_API_KEY environment variable is not set")
+    return genai.Client(api_key=key)

--- a/src/chainlit_gemini_mcp/mcp_utils.py
+++ b/src/chainlit_gemini_mcp/mcp_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+import chainlit as cl
+from mcp import ClientSession
+
+
+async def store_tools(connection, session: ClientSession) -> None:
+    """Store tools discovered on a new MCP connection."""
+    result = await session.list_tools()
+    tools = [
+        {
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.inputSchema,
+        }
+        for t in result.tools
+    ]
+    mcp_tools = cl.user_session.get("mcp_tools", {})
+    mcp_tools[connection.name] = tools
+    cl.user_session.set("mcp_tools", mcp_tools)
+
+
+async def remove_tools(name: str) -> None:
+    """Remove tools when an MCP connection is closed."""
+    mcp_tools = cl.user_session.get("mcp_tools", {})
+    mcp_tools.pop(name, None)
+    cl.user_session.set("mcp_tools", mcp_tools)
+
+
+def find_mcp_for_tool(tool_name: str, mcp_tools: Dict[str, Iterable[Dict[str, Any]]]):
+    """Return the MCP connection name that exposes ``tool_name``."""
+    for name, tools in mcp_tools.items():
+        for tool in tools:
+            if tool.get("name") == tool_name:
+                return name
+    return None
+
+
+async def call_mcp_tool(
+    tool_name: str,
+    tool_input: Dict[str, Any],
+    mcp_tools: Dict[str, Iterable[Dict[str, Any]]],
+    mcp_sessions: Dict[str, ClientSession],
+) -> Any:
+    """Call a tool on the appropriate MCP connection."""
+    name = find_mcp_for_tool(tool_name, mcp_tools)
+    if not name:
+        raise ValueError(f"Tool '{tool_name}' not found")
+
+    session = mcp_sessions[name]
+    result = await session.call_tool(tool_name, tool_input)
+    return getattr(result, "output", result)

--- a/src/chainlit_gemini_mcp/mcp_utils.py
+++ b/src/chainlit_gemini_mcp/mcp_utils.py
@@ -4,6 +4,9 @@ from typing import Any, Dict, Iterable
 
 import chainlit as cl
 from mcp import ClientSession
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 async def store_tools(connection, session: ClientSession) -> None:
@@ -20,6 +23,7 @@ async def store_tools(connection, session: ClientSession) -> None:
     mcp_tools = cl.user_session.get("mcp_tools", {})
     mcp_tools[connection.name] = tools
     cl.user_session.set("mcp_tools", mcp_tools)
+    logger.info("Stored %d tools for connection '%s'", len(tools), connection.name)
 
 
 async def remove_tools(name: str) -> None:
@@ -27,6 +31,7 @@ async def remove_tools(name: str) -> None:
     mcp_tools = cl.user_session.get("mcp_tools", {})
     mcp_tools.pop(name, None)
     cl.user_session.set("mcp_tools", mcp_tools)
+    logger.info("Removed tools for connection '%s'", name)
 
 
 def find_mcp_for_tool(tool_name: str, mcp_tools: Dict[str, Iterable[Dict[str, Any]]]):
@@ -45,8 +50,14 @@ async def call_mcp_tool(
     mcp_sessions: Dict[str, ClientSession],
 ) -> Any:
     """Call a tool on the appropriate MCP connection."""
+    logger.info(
+        "call_mcp_tool requested: tool_name=%s, input=%s",
+        tool_name,
+        tool_input,
+    )
     name = find_mcp_for_tool(tool_name, mcp_tools)
     if not name:
+        logger.warning("Requested tool '%s' not found", tool_name)
         raise ValueError(f"Tool '{tool_name}' not found")
 
     session = mcp_sessions[name]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import logging
+import pytest
+
+os.environ.setdefault("GOOGLE_API_KEY", "key")
+
+sys.path.insert(0, os.path.abspath("src"))
+
+import asyncio
+import chainlit as cl
+from chainlit_gemini_mcp import app
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class DummyMessage:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class DummyCLMessage:
+    def __init__(self, *, content: str):
+        self.content = content
+
+    async def send(self):
+        DummyCLMessage.sent = self.content
+
+
+async def fake_generate_content(**_):
+    return DummyResponse("hello")
+
+
+def test_on_message_logs_response(monkeypatch, caplog):
+    monkeypatch.setattr(
+        app.client.aio.models, "generate_content", fake_generate_content
+    )
+    monkeypatch.setattr(cl, "Message", DummyCLMessage)
+
+    with caplog.at_level(logging.DEBUG):
+        asyncio.run(app.on_message(DummyMessage("hi")))
+
+    assert DummyCLMessage.sent == "hello"
+    assert any("hello" in record.getMessage() for record in caplog.records)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,18 @@ def test_call_mcp_tool():
     assert session.called == ("get_current_weather", {"location": "paris"})
 
 
+def test_call_mcp_tool_missing():
+    with pytest.raises(ValueError):
+        asyncio.run(
+            call_mcp_tool(
+                "get_current_weather",
+                {"location": "lyon"},
+                {},
+                {},
+            )
+        )
+
+
 def test_find_mcp_for_tool():
     tools = {"c1": [{"name": "foo"}], "c2": [{"name": "bar"}]}
     assert find_mcp_for_tool("bar", tools) == "c2"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+
+from chainlit_gemini_mcp.gemini_client import get_client
+from chainlit_gemini_mcp.mcp_utils import find_mcp_for_tool, call_mcp_tool
+
+
+class DummySession:
+    def __init__(self):
+        self.called = None
+
+    class Result:
+        def __init__(self, output: str):
+            self.output = output
+
+    async def call_tool(self, name, arguments=None, **_):
+        self.called = (name, arguments)
+        return self.Result(f"ok:{arguments['location']}")
+
+
+def test_call_mcp_tool():
+    mcp_tools = {"conn": [{"name": "get_current_weather"}]}
+    session = DummySession()
+    result = asyncio.run(
+        call_mcp_tool(
+            "get_current_weather",
+            {"location": "paris"},
+            mcp_tools,
+            {"conn": session},
+        )
+    )
+    assert result == "ok:paris"
+    assert session.called == ("get_current_weather", {"location": "paris"})
+
+
+def test_find_mcp_for_tool():
+    tools = {"c1": [{"name": "foo"}], "c2": [{"name": "bar"}]}
+    assert find_mcp_for_tool("bar", tools) == "c2"
+    assert find_mcp_for_tool("missing", tools) is None
+
+
+def test_get_client(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "key")
+    client = get_client()
+    assert hasattr(client, "models")


### PR DESCRIPTION
## Summary
- configure project with pyproject.toml and uv
- implement Gemini client helper
- implement MCP integration utilities
- create Chainlit app using Gemini function calling
- provide basic tests and docs
- ignore local Chainlit config

## Testing
- `black -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684117879e5c832ebb267e3ead7ecf49