### PR TITLE
Add missing tool error test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,18 @@ def test_call_mcp_tool():
     assert session.called == ("get_current_weather", {"location": "paris"})
 
 
+def test_call_mcp_tool_missing():
+    with pytest.raises(ValueError):
+        asyncio.run(
+            call_mcp_tool(
+                "get_current_weather",
+                {"location": "lyon"},
+                {},
+                {},
+            )
+        )
+
+
 def test_find_mcp_for_tool():
     tools = {"c1": [{"name": "foo"}], "c2": [{"name": "bar"}]}
     assert find_mcp_for_tool("bar", tools) == "c2"


### PR DESCRIPTION
## Summary
- ensure `call_mcp_tool` raises `ValueError` when the tool isn't present

## Testing
- `uv pip install -e .[dev] --system`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412f8f11ac832ebe125d7b3c4fd3eb