### PR TITLE
Log Gemini response text

### DIFF
--- a/src/chainlit_gemini_mcp/app.py
+++ b/src/chainlit_gemini_mcp/app.py
@@ -56,4 +56,5 @@ async def on_message(message: cl.Message):
         contents=message.content,
         config=types.GenerateContentConfig(tools=[get_current_weather]),
     )
+    logger.debug("Model response text: %s", response.text)
     await cl.Message(content=response.text).send()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import logging
+import pytest
+
+os.environ.setdefault("GOOGLE_API_KEY", "key")
+
+sys.path.insert(0, os.path.abspath("src"))
+
+import asyncio
+import chainlit as cl
+from chainlit_gemini_mcp import app
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class DummyMessage:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class DummyCLMessage:
+    def __init__(self, *, content: str):
+        self.content = content
+
+    async def send(self):
+        DummyCLMessage.sent = self.content
+
+
+async def fake_generate_content(**_):
+    return DummyResponse("hello")
+
+
+def test_on_message_logs_response(monkeypatch, caplog):
+    monkeypatch.setattr(
+        app.client.aio.models, "generate_content", fake_generate_content
+    )
+    monkeypatch.setattr(cl, "Message", DummyCLMessage)
+
+    with caplog.at_level(logging.DEBUG):
+        asyncio.run(app.on_message(DummyMessage("hi")))
+
+    assert DummyCLMessage.sent == "hello"
+    assert any("hello" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- log Gemini response text in `on_message`
- test that the debug statement logs the text

## Testing
- `uv pip install -e .[dev] --system`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841439ff570832e90cebde0395bca5f